### PR TITLE
Fix log level options

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,7 @@ func parseLevel(level string) (slog.Level, bool) {
 		return slog.LevelDebug, true
 	case "info":
 		return slog.LevelInfo, true
-	case "warn":
+	case "warning":
 		return slog.LevelWarn, true
 	case "error":
 		return slog.LevelError, true
@@ -77,7 +77,7 @@ func registerFlags() {
 	flag.String("exporter.partitions", "", "A comma separated list of partitions which to export. (default: all)")
 	flag.String("exporter.config", "", "bigip_exporter configuration file name.")
 	flag.String("exporter.namespace", "bigip", "bigip_exporter namespace.")
-	flag.String("exporter.log_level", "info", "Available options are trace, debug, info, warning, error and critical")
+	flag.String("exporter.log_level", "info", "Available options are debug, info, warning, and error")
 }
 
 func bindFlags() {


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the log level option by changing 'warn' to 'warning' and update the flag registration to accurately list the available log level options.

Bug Fixes:
- Correct the log level option from 'warn' to 'warning' in the configuration parsing logic.

Enhancements:
- Update the log level options in the flag registration to reflect the correct available options.

<!-- Generated by sourcery-ai[bot]: end summary -->